### PR TITLE
Provide version rewrite using a regex pattern and replacement.

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -31,6 +31,17 @@ class cli():
                                  'source using this format string. '
                                  'This parameter is used if the \'version\' '
                                  'parameter is not specified.')
+        parser.add_argument('--versionrewrite-pattern',
+                            help='Regex used to rewrite the version which is '
+                                 'applied post versionformat. For example, to '
+                                 'remove a tag prefix of "v" the regex "v(.*)" '
+                                 'could be used. See the '
+                                 'versionrewrite-replacement parameter.')
+        parser.add_argument('--versionrewrite-replacement',
+                            default=r'\1',
+                            help='Replacement applied to rewrite pattern. '
+                                 'Typically backreferences are useful and as '
+                                 'such defaults to \\1.')
         parser.add_argument('--versionprefix',
                             help='Specify a base version as prefix.')
         parser.add_argument('--parent-tag',

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -163,6 +163,9 @@ class tasks():
         version = args.version
         if version == '_auto_' or args.versionformat:
             version = self.detect_version(scm_object, args)
+        if args.versionrewrite_pattern:
+            regex = re.compile(args.versionrewrite_pattern)
+            version = regex.sub(args.versionrewrite_replacement, version)
         if args.versionprefix:
             version = "%s.%s" % (args.versionprefix, version)
 

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -61,6 +61,19 @@
       For bzr and svn, '%r' is expanded to the revision, and is the default.
     </description>
   </parameter>
+  <parameter name="versionrewrite-pattern">
+    <description>
+      Regex used to rewrite the version which is applied post versionformat. For
+      example, to remove a tag prefix of "v" the regex "v(.*)" could be used.
+      See the versionrewrite-replacement parameter.
+    </description>
+  </parameter>
+  <parameter name="versionrewrite-replacement">
+    <description>
+      Replacement applied to rewrite pattern. Typically backreferences are
+      useful and as such defaults to \1.
+    </description>
+  </parameter>
   <parameter name="versionprefix">
     <description>Specify a base version as prefix.</description>
   </parameter>


### PR DESCRIPTION
Nicely rewrite the very common `v1.0.0` style tags to `1.0.0` which works properly with rpm `%setup` and `set_version` service.